### PR TITLE
fix: remove signals to update table when using filters - effort page

### DIFF
--- a/src/components/Month.tsx
+++ b/src/components/Month.tsx
@@ -1,4 +1,4 @@
-import { $, PropFunction, component$, useSignal } from '@builder.io/qwik';
+import { $, PropFunction, component$ } from '@builder.io/qwik';
 import { t } from '../locale/labels';
 import { putEffort } from '../utils/api';
 import { getDateLabelFromMonthYear } from '../utils/dates';
@@ -9,10 +9,6 @@ export const Month = component$<{
 	month: TMonth;
 	onChange$: PropFunction<() => void>;
 }>(({ name, month, onChange$ }) => {
-	const confirmedSig = useSignal(month.confirmedEffort);
-	const tentativeEffortSig = useSignal(month.tentativeEffort);
-	const notesSig = useSignal(month.notes.toString());
-
 	const updateMonth = $(async (month: TMonth) => {
 		await putEffort(name, month);
 		await onChange$();
@@ -29,17 +25,15 @@ export const Month = component$<{
 					<input
 						type='number'
 						class='border-2 border-black w-[50px] h-8 mt-2'
-						value={confirmedSig.value}
+						value={month.confirmedEffort}
 						min={0}
 						max={100}
-						onChange$={(e) => {
-							confirmedSig.value = parseInt(e.target.value, 10);
-							const newMonth = {
+						onChange$={({ target: { value } }) =>
+							updateMonth({
 								...month,
-								confirmedEffort: confirmedSig.value,
-							};
-							updateMonth(newMonth);
-						}}
+								confirmedEffort: parseInt(value, 10),
+							})
+						}
 					/>
 				</div>
 				<div class='flex-col m-2'>
@@ -47,17 +41,15 @@ export const Month = component$<{
 					<input
 						type='number'
 						class='border-2 border-black w-[50px] h-8 mt-2'
-						value={tentativeEffortSig.value}
+						value={month.tentativeEffort}
 						min={0}
 						max={100}
-						onChange$={(e) => {
-							tentativeEffortSig.value = parseInt(e.target.value, 10);
-							const newMonth = {
+						onChange$={({ target: { value } }) =>
+							updateMonth({
 								...month,
-								tentativeEffort: tentativeEffortSig.value,
-							};
-							updateMonth(newMonth);
-						}}
+								tentativeEffort: parseInt(value, 10),
+							})
+						}
 					/>
 				</div>
 				<div class='flex-col m-2'>
@@ -65,12 +57,13 @@ export const Month = component$<{
 					<input
 						type='text'
 						class='border-2 border-black w-[200px] h-8 mt-2'
-						value={notesSig.value}
-						onChange$={(e) => {
-							(notesSig.value = e.target.value), 10;
-							const newMonth = { ...month, notes: notesSig.value };
-							updateMonth(newMonth);
-						}}
+						value={month.notes}
+						onChange$={({ target: { value } }) =>
+							updateMonth({
+								...month,
+								notes: value,
+							})
+						}
 					/>
 				</div>
 			</div>


### PR DESCRIPTION
When crew filter is selected values in the input fields (Month component) weren't updated