### PR TITLE
fix: logout function

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -46,11 +46,12 @@ export const Header = component$<{ currentRoute: MenuRoutes }>(({ currentRoute }
 					<button
 						class='bg-transparent inline-flex items-center gap-2 text-dark-grey font-semibold p-2 m-2 rounded border-0 min-w-[100px]'
 						onClick$={() => {
-							removeCookie(COOKIE_TOKEN_KEY);
-							auth0.logout({
-								logoutParams: {
-									returnTo: redirect_uri,
-								},
+							removeCookie(COOKIE_TOKEN_KEY, () => {
+								auth0.logout({
+									logoutParams: {
+										returnTo: redirect_uri,
+									},
+								});
 							});
 						}}
 					>

--- a/src/components/UserProfileCard.tsx
+++ b/src/components/UserProfileCard.tsx
@@ -42,8 +42,7 @@ export const UserProfileCard = component$(() => {
 		if (!Object.keys(appStore.configuration.skills).length) {
 			const configuration = await getConfiguration();
 			if (!configuration) {
-				removeCookie(COOKIE_TOKEN_KEY);
-				navigateTo('auth');
+				removeCookie(COOKIE_TOKEN_KEY, () => navigateTo('auth'));
 			}
 			appStore.configuration = configuration;
 		}

--- a/src/page/Effort.tsx
+++ b/src/page/Effort.tsx
@@ -81,16 +81,14 @@ export const Effort = component$(() => {
 		if (!Object.keys(appStore.configuration.skills).length) {
 			const configuration = await getConfiguration();
 			if (!configuration) {
-				removeCookie(COOKIE_TOKEN_KEY);
-				navigateTo('auth');
+				removeCookie(COOKIE_TOKEN_KEY, () => navigateTo('auth'));
 			}
 			appStore.configuration = configuration;
 		}
 
 		const effort = await getEffort();
 		if (!effort) {
-			removeCookie(COOKIE_TOKEN_KEY);
-			navigateTo('auth');
+			removeCookie(COOKIE_TOKEN_KEY, () => navigateTo('auth'));
 		}
 
 		effortSig.value = effort;

--- a/src/page/Skills.tsx
+++ b/src/page/Skills.tsx
@@ -83,16 +83,14 @@ export const Skills = component$(() => {
 		if (!Object.keys(appStore.configuration.skills).length) {
 			const configuration = await getConfiguration();
 			if (!configuration) {
-				removeCookie(COOKIE_TOKEN_KEY);
-				navigateTo('auth');
+				removeCookie(COOKIE_TOKEN_KEY, () => navigateTo('auth'));
 			}
 			appStore.configuration = configuration;
 		}
 
 		const skills = await getSkills();
 		if (!skills) {
-			removeCookie(COOKIE_TOKEN_KEY);
-			navigateTo('auth');
+			removeCookie(COOKIE_TOKEN_KEY, () => navigateTo('auth'));
 		}
 
 		originalSkillMatrixSig.value = skills;

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -29,6 +29,7 @@ export const getCookie = (name: string) => {
 	return null;
 };
 
-export const removeCookie = (name: string) => {
+export const removeCookie = (name: string, cb: Function) => {
 	document.cookie = name + '=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+	cb();
 };


### PR DESCRIPTION
The logout function is composed of two steps:

- First: expiring the cookie function
- Second: redirecting to the authentication page

The problem was that the second step ran faster than the first, causing the first step not to run. The user remained where they were without actually logging out.

 To fix it, I added a callback function to execute after the authentication cookie had expired.